### PR TITLE
fix menu input name when we quit

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -345,7 +345,7 @@ class ScoreMenu(Menu):                               # single과 dual 게임 종
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     self.running, self.playing = False, False
-                    self.curr_menu.run_display = False
+                    self.run_display = False
                 if event.type == pygame.KEYDOWN:
                     if event.key == pygame.K_RETURN:
                         self.run_display = False


### PR DESCRIPTION
Before, when we leave the program when we had to put our name, the program crash.
Now, we can leave the program in this menu without crash.